### PR TITLE
Refine TeX rendering

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1962,13 +1962,35 @@ async def cmd_tex(msg: discord.Message, formula: str) -> None:
         )
         return
 
-    fig = plt.figure()
-    fig.text(0.5, 0.5, f"${formula}$", fontsize=20, ha="center", va="center")
-    plt.axis("off")
+    plt.rcParams.update({
+        "mathtext.fontset": "cm",
+        "font.family": "serif",
+    })
+
+    # 余白を抑えるため一度描画し、テキストの bbox からキャンバスサイズを求める
+    dpi = 300
+    pad = 0.05
+    fig = plt.figure(dpi=dpi)
+    text = fig.text(0, 0, f"${formula}$", fontsize=20)
+    fig.canvas.draw()
+    bbox = text.get_window_extent()
+    width, height = bbox.width / dpi, bbox.height / dpi
+    fig.set_size_inches(width * (1 + pad), height * (1 + pad))
+    text.set_position((pad / 2, pad / 2))
+    text.set_transform(fig.transFigure)
+    fig.canvas.draw()
+
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
     path = tmp.name
     tmp.close()
-    await asyncio.to_thread(fig.savefig, path, bbox_inches="tight", pad_inches=0.2)
+    await asyncio.to_thread(
+        fig.savefig,
+        path,
+        dpi=dpi,
+        transparent=True,
+        bbox_inches="tight",
+        pad_inches=0,
+    )
     plt.close(fig)
 
     try:


### PR DESCRIPTION
## Summary
- use figure coordinates for TeX placement
- redraw after resizing to avoid gaps
- export with transparent background and tight bbox

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687318f92260832ca0fa1882d40b5f3b