### PR TITLE
Refine TeX error handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1962,13 +1962,49 @@ async def cmd_tex(msg: discord.Message, formula: str) -> None:
         )
         return
 
-    fig = plt.figure()
-    fig.text(0.5, 0.5, f"${formula}$", fontsize=20, ha="center", va="center")
-    plt.axis("off")
+    plt.rcParams.update(
+        {
+            "text.usetex": True,
+            "font.family": "serif",
+            "text.latex.preamble": r"\usepackage{amsmath}",
+        }
+    )
+
+    # 余白を抑えるため一度描画し、テキストの bbox からキャンバスサイズを求める
+    dpi = 300
+    pad = 0.05
+    fig = plt.figure(dpi=dpi)
+    text = fig.text(
+        0,
+        0,
+        f"${formula}$",
+        fontsize=20,
+        ha="left",
+        va="bottom",
+    )
+    try:
+        fig.canvas.draw()
+        bbox = text.get_window_extent()
+        width, height = bbox.width / dpi, bbox.height / dpi
+        fig.set_size_inches(width * (1 + pad), height * (1 + pad))
+        text.set_position((pad / 2, pad / 2))
+        text.set_transform(fig.transFigure)
+        fig.canvas.draw()
+    except Exception:
+        plt.close(fig)
+        await msg.reply("数式の構文が間違っているよ！")
+        return
+
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
     path = tmp.name
     tmp.close()
-    await asyncio.to_thread(fig.savefig, path, bbox_inches="tight", pad_inches=0.2)
+    await asyncio.to_thread(
+        fig.savefig,
+        path,
+        dpi=dpi,
+        transparent=True,
+        pad_inches=0.05,
+    )
     plt.close(fig)
 
     try:


### PR DESCRIPTION
## Summary
- catch mathtext parse errors and reply when formula is invalid
- save TeX images with a fixed 0.05‑inch margin
- enable LaTeX engine for full syntax support

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687318f92260832ca0fa1882d40b5f3b