### PR TITLE
Show TeX error in response

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2003,12 +2003,13 @@ async def cmd_tex(msg: discord.Message, formula: str) -> None:
     except Exception as e:
         plt.close(fig)
         err = str(e)
+        logger.exception("TeX rendering failed: %s", err)
         if "latex could not be found" in err or "dvipng was not found" in err:
             await msg.reply(
                 "LaTeX 環境 (latex, dvipng) が見つかりません。インストールしてください。"
             )
         else:
-            await msg.reply("数式の構文が間違っているよ！")
+            await msg.reply(f"数式の構文が間違っているよ！\n```\n{err}\n```")
         return
 
 


### PR DESCRIPTION
## Summary
- show full exception text when TeX command fails
- log TeX rendering errors

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_687328d2eeb0832cbb8051a724a6a87f